### PR TITLE
Make a questionable headless mode

### DIFF
--- a/include/mainwindow.h
+++ b/include/mainwindow.h
@@ -71,6 +71,7 @@ public slots:
     void reconnectBlueStatusSocket();
     void reconnectVisionSocket();
     void recvActions();
+    void setIsGlEnabled(bool value);
 private:
     int getInterval();    
     QTimer *timer;

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -73,6 +73,7 @@ int main(int argc, char *argv[])
     }
     else {
       w.hide();
+      w.setIsGlEnabled(false);
     }
     return a.exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -62,18 +62,19 @@ refactor variable names
 
 int main(int argc, char *argv[])
 {
+	char** argend = argc + argv;
+
     QCoreApplication::setOrganizationName("Parsian");
     QCoreApplication::setOrganizationDomain("parsian-robotics.com");
     QCoreApplication::setApplicationName("grSim");
     QApplication a(argc, argv);
     MainWindow w;
 
-    if (argc == 1 || strcmp(argv[1], "-headless") != 0) {
+	if (std::find(argv, argend, std::string("-headless")) == argend) {
       w.show();
-    }
-    else {
+	} else {
       w.hide();
       w.setIsGlEnabled(false);
-    }
-    return a.exec();
+	}
+	return a.exec();
 }

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -67,6 +67,12 @@ int main(int argc, char *argv[])
     QCoreApplication::setApplicationName("grSim");
     QApplication a(argc, argv);
     MainWindow w;
-    w.show();
+
+    if (argc == 1 || strcmp(argv[1], "-headless") != 0) {
+      w.show();
+    }
+    else {
+      w.hide();
+    }
     return a.exec();
 }

--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -519,3 +519,7 @@ void MainWindow::recvActions()
     glwidget->ssl->recvActions();
 }
 
+void MainWindow::setIsGlEnabled(bool value)
+{
+  glwidget->ssl->isGLEnabled = value;
+}


### PR DESCRIPTION
Adds a headless mode to grSim. Currently, I am not sure if this actually disables the openGL window or just hides it so I will need to test that. If it doesn't, I should be able to just have the headless mode also change the flag that @ashaw596 found. The headless mode is activated by passing the argument -headless to grSim.